### PR TITLE
fix: move swift-tools-version comment to line 1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,5 @@
-import Foundation
 // swift-tools-version: 5.5
+import Foundation
 import PackageDescription
 
 // Read version from package.json


### PR DESCRIPTION
## Problem

When adding the Capacitor `CapApp-SPM` package in Xcode, resolution fails because `swift-tools-version` is not on line 1 of `Package.swift`.

Currently, `import Foundation` is on line 1, but SPM requires `swift-tools-version` to be the first line.

Fixes #9

## Fix

Move `// swift-tools-version: 5.5` to line 1, before `import Foundation`.
